### PR TITLE
Cleanup README and loosen version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ care of authentication with Azure Artifacts feeds. This is heavily based on
 
 ## Usage
 
+This plugin requires Python 3.9+ which is a bit less lenient than Poetry itself.
+
 Install this plugin with
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,13 +37,12 @@ priority = "primary"
 
 Now, when running `poetry install`, or `poetry lock`, Poetry will automatically
 fetch credentials for your Azure Artifacts feed, utilizing
-[artifact-keyring](https://github.com/microsoft/artifact-keyring).
+[artifacts-keyring](https://github.com/microsoft/artifacts-keyring).
+Note: `artifacts-keyring` requires `dotnet` to be installed and available in your PATH.
 
-This works automatically by recognizing authentication failures to URLs containing
-`pkgs.dev.azure.com` and `pkgs.visualstudio.com`.
-
-If you have an on-premises Azure DevOps server,
-make the source name include the text `azure-artifacts`:
+This works by recognizing authentication failures to URLs containing
+`pkgs.dev.azure.com` and `pkgs.visualstudio.com`. If you have an on-premises
+Azure DevOps server, make the source name include the text `azure-artifacts`:
 
 ```toml
 [[tool.poetry.source]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -28,8 +28,10 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "os_name == \"nt\""}
+importlib-metadata = {version = ">=4.6", markers = "python_full_version < \"3.10.2\""}
 packaging = ">=19.1"
 pyproject_hooks = "*"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["furo (>=2023.08.17)", "sphinx (>=7.0,<8.0)", "sphinx-argparse-cli (>=1.5)", "sphinx-autodoc-typehints (>=1.10)", "sphinx-issues (>=3.0.0)"]
@@ -499,6 +501,25 @@ files = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.2.0"
+description = "Read metadata from Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "importlib_metadata-8.2.0-py3-none-any.whl", hash = "sha256:11901fa0c2f97919b288679932bb64febaeacf289d18ac84dd68cb2e74213369"},
+    {file = "importlib_metadata-8.2.0.tar.gz", hash = "sha256:72e8d4399996132204f9a16dcc751af254a48f8d1b20b9ff0f98d4a8f901e73d"},
+]
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+perf = ["ipython"]
+test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+
+[[package]]
 name = "installer"
 version = "0.7.0"
 description = "A library for installing Python wheels."
@@ -554,6 +575,7 @@ files = [
 ]
 
 [package.dependencies]
+importlib-metadata = {version = ">=4.11.4", markers = "python_version < \"3.12\""}
 "jaraco.classes" = "*"
 jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
 pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
@@ -724,6 +746,7 @@ cleo = ">=2.1.0,<3.0.0"
 crashtest = ">=0.4.1,<0.5.0"
 dulwich = ">=0.21.2,<0.22.0"
 fastjsonschema = ">=2.18.0,<3.0.0"
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 installer = ">=0.7.0,<0.8.0"
 keyring = ">=24.0.0,<25.0.0"
 packaging = ">=23.1"
@@ -736,6 +759,7 @@ pyproject-hooks = ">=1.0.0,<2.0.0"
 requests = ">=2.26,<3.0"
 requests-toolbelt = ">=1.0.0,<2.0.0"
 shellingham = ">=1.5,<2.0"
+tomli = {version = ">=2.0.1,<3.0.0", markers = "python_version < \"3.11\""}
 tomlkit = ">=0.11.4,<1.0.0"
 trove-classifiers = ">=2022.5.19"
 virtualenv = ">=20.23.0,<21.0.0"
@@ -1073,6 +1097,17 @@ files = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.13.0"
 description = "Style preserving TOML library"
@@ -1204,7 +1239,22 @@ cffi = ">=1.16.0"
 [package.extras]
 test = ["pytest"]
 
+[[package]]
+name = "zipp"
+version = "3.19.2"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},
+    {file = "zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19"},
+]
+
+[package.extras]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "daa973be84d4681a4b2e86a5f62df7c67903c404d9d2b41a66c5543676949150"
+python-versions = "^3.9"
+content-hash = "94a0b761e17d8058ebfbbc886559c8318b233aba9a52592ba6b48359176386c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@
     Issues = "https://github.com/NathanVaughn/poetry-azure-artifacts-plugin/issues"
 
 [tool.poetry.dependencies]
-    python            = "^3.12"
+    # https://github.com/python-poetry/poetry/blob/main/pyproject.toml#L32
+    python            = "^3.9"
     artifacts-keyring = "^0.3.6"
     poetry            = "^1.8.3"
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update README to clarify version requirements and dependencies, and improve instructions for handling authentication failures and on-premises Azure DevOps server configurations.

Documentation:
- Updated README to specify that the plugin requires Python 3.9+.
- Clarified that `artifacts-keyring` requires `dotnet` to be installed and available in the PATH.
- Revised instructions for handling authentication failures and on-premises Azure DevOps server configurations.

<!-- Generated by sourcery-ai[bot]: end summary -->