### PR TITLE
Add Python 3.13 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Poetry Test Version
         run: |
           vtr build
-          uv tool install --with ./dist/poetry_azure_artifacts_plugin*.whl poetry==${{ matrix.poetry_version }}
+          uv tool install --with ./dist/poetry_azure_artifacts_plugin*.whl poetry==${{ matrix.poetry_version }} --python ${{ matrix.python_version }}
 
       - name: Test Poetry
         # at least make sure it doesn't crash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         poetry_version: ${{ fromJSON(needs.bake.outputs.poetry_versions) }}
-        python_version: ["3.12", "3.11", "3.10", "3.9"]
+        python_version: ["3.13", "3.12", "3.11", "3.10", "3.9"]
 
     if: "${{ !contains(github.event.head_commit.message, 'ci skip') }}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
     name = "poetry-azure-artifacts-plugin"
-    version = "0.1.1"
+    version = "0.1.2"
     description = "Poetry plugin to handle Azure Artifacts authentication"
     readme = "README.md"
     authors = [{ name = "Nathan Vaughn", email = "nath@nvaughn.email" }]
@@ -13,6 +13,7 @@
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ]
     requires-python = ">=3.9"
     dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -567,7 +567,7 @@ wheels = [
 
 [[package]]
 name = "poetry-azure-artifacts-plugin"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "artifacts-keyring" },


### PR DESCRIPTION
## Summary by Sourcery

Add support for Python 3.13 in the CI testing matrix.

CI:
- Add Python 3.13 to the matrix of Python versions in the CI workflow.